### PR TITLE
Add CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.1
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: |
+          sudo apt-get install pandoc 
+          sudo apt-get install --no-install-recommends -y \
+              texlive-latex-recommended texlive-latex-extra \
+              texlive-fonts-recommended latexmk
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv /tmp/venv
+            . /tmp/venv/bin/activate
+            pip install ipython notebook sphinx
+      - run:
+           name: build HTML
+           command: |
+            . /tmp/venv/bin/activate
+            make html
+      - run:
+           name: build PDF
+           command: |
+            . /tmp/venv/bin/activate
+            # TODO: the nonstopmode option is necessary to avoid timeouts 
+            # when compilation errors occurs (e.g. some images are not found).
+            make pdf LATEXOPTS="--interaction=nonstopmode"
+      - store_artifacts:
+          path: build/html/
+          destination: html/
+      - store_artifacts:
+          path: build/latex/StatisticsMachineLearningPython.pdf
+          destination: pdf/StatisticsMachineLearningPython.pdf


### PR DESCRIPTION
This PR adds a continuous integration setup with Circle CI to check that the html and pdf files can be built at each commit.  [Circle CI](circleci.com) would need to be enabled on this repo for this to work.

Currently, the pdf build still fails (see [logs](https://circleci.com/gh/rth/pystatsml/13?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)) because `python/images/numpy_broadcasting.png` was not found.  The links to the generated html and pdf files can be found in the ["Artifacts" tab](https://circleci.com/gh/rth/pystatsml/13#artifacts/containers/0). 

The generated pdf version doesn't look right, not sure if it's due to the missing png or something else.

cc @duchesnay